### PR TITLE
test(PanoVideo): add video format for Safari

### DIFF
--- a/test/manual/PanoViewer/PanoVideo.html
+++ b/test/manual/PanoViewer/PanoVideo.html
@@ -37,9 +37,10 @@
       <h3>Available on Chrome Browser</h3>
       Video Source: <a href="https://github.com/mrdoob/three.js/blob/master/examples/textures/pano.webm">https://github.com/mrdoob/three.js/blob/master/examples/textures/pano.webm</a>
       <!--<div class="360-area">-->
-        <video id="videoSrc" style="width:100%;height:400px;display:none" src="../img/PanoViewer/pano.webm"></video>
-        <!-- <video id="videoSrc" style="width:100%;height:400px;display:none" src="../img/PanoViewer/720p.mkv"></video> -->
-        <!-- <video id="videoSrc" style="width:100%;height:400px" src="https://pannellum.org/images/video/jfk.webm"></video> -->
+        <video id="videoSrc" style="width:100%;height:400px;display:none">
+          <source src="../img/PanoViewer/pano.webm" type="video/webm">
+          <source src="../img/PanoViewer/pano.mp4" type="video/mp4">
+        </video>
         <div class="photo360">
           <!--<img class="preloaded_image hidden_elem" src="../img/book_equi_1.jpg"/>-->
         </div>


### PR DESCRIPTION
## Issue
#79

## Details
Safari was not working because previous video format(webm) is not available on Safari. so I converted it to safari supported format.