### PR TITLE
feat(PanoImageRenderer): Refactoring/tune renderer & add keepUpdate

### DIFF
--- a/src/PanoImageRenderer/PanoImageRenderer.js
+++ b/src/PanoImageRenderer/PanoImageRenderer.js
@@ -457,7 +457,8 @@ export default class PanoImageRenderer extends Component {
 	}
 
 	keepUpdate(doUpdate) {
-		if (doUpdate && !this._keepUpdate) {
+		if (doUpdate && this.isImageLoaded() === false) {
+			// Force to draw a frame after image is loaded on render()
 			this._shouldForceDraw = true;
 		}
 

--- a/src/PanoImageRenderer/PanoImageRenderer.js
+++ b/src/PanoImageRenderer/PanoImageRenderer.js
@@ -457,6 +457,10 @@ export default class PanoImageRenderer extends Component {
 	}
 
 	keepUpdate(doUpdate) {
+		if (doUpdate && !this._keepUpdate) {
+			this._shouldForceDraw = true;
+		}
+
 		this._keepUpdate = doUpdate;
 	}
 

--- a/src/PanoImageRenderer/WebGLUtils.js
+++ b/src/PanoImageRenderer/WebGLUtils.js
@@ -42,7 +42,7 @@ export default class WebGLUtils {
 		return null;
 	}
 
-	static initBuffer(gl, target /* bind point */, data, itemSize) {
+	static initBuffer(gl, target /* bind point */, data, itemSize, attr) {
 		const buffer = gl.createBuffer();
 
 		gl.bindBuffer(target, buffer);
@@ -51,6 +51,11 @@ export default class WebGLUtils {
 		if (buffer) {
 			buffer.itemSize = itemSize;
 			buffer.numItems = data.length / itemSize;
+		}
+
+		if (attr !== undefined) {
+			gl.enableVertexAttribArray(attr);
+			gl.vertexAttribPointer(attr, buffer.itemSize, gl.FLOAT, false, 0, 0);
 		}
 
 		return buffer;

--- a/src/PanoViewer/PanoViewer.js
+++ b/src/PanoViewer/PanoViewer.js
@@ -194,6 +194,11 @@ export default class PanoViewer extends Component {
 		return this;
 	}
 
+	keepUpdate(doUpdate) {
+		this._photoSphereRenderer.keepUpdate(doUpdate);
+		return this;
+	}
+
 	/**
 	 * Get projection type (equirectangular/cube)
 	 * @ko 프로젝션 타입(Equirectangular 혹은 Cube)을 반환한다.


### PR DESCRIPTION
## Issue
#89

## Details
1.  Shorten image load process (<-- It makes better performance)
2. Add `keepUpdate` interface #93
3. Refactoring Code 
> WebGL Command is captured using [WebGL Inspector](http://benvanik.github.io/WebGL-Inspector/
  - ![refactoring-command](https://user-images.githubusercontent.com/3255471/34249324-b6d11958-e67c-11e7-8525-e631f758c70b.png)
  - Remove useless code
    - (like `!this.hasRenderingContext()` check. because render function should be called after rendering context sucessfull)


