### PR TITLE
refactor(all): remove contentLoaded event.

### DIFF
--- a/src/PanoImageRenderer/PanoImageRenderer.js
+++ b/src/PanoImageRenderer/PanoImageRenderer.js
@@ -182,14 +182,7 @@ export default class PanoImageRenderer extends Component {
 	_onContentLoad(image) {
 		this._imageIsReady = true;
 
-		if (this._isVideo) {
-			this._image.addEventListener("loadeddata", () => {
-				this._triggerContentLoad();
-			});
-		} else {
-			this._triggerContentLoad();
-		}
-
+		this._triggerContentLoad();
 		return true;
 	}
 

--- a/src/PanoViewer/PanoViewer.js
+++ b/src/PanoViewer/PanoViewer.js
@@ -363,18 +363,6 @@ export default class PanoViewer extends Component {
 		 *		// animation is ended.
 		 * });
 		 */
-
-		/**
-			* Events that is fired when content(Video/Image) is loaded
-			* @ko 컨텐츠(비디오 혹은 이미지)가 로드되었을때 발생되는 이벤트
-			*
-			* @name eg.view360.PanoViewer#contentLoaded
-			* @event
-			* @param {Object} event
-			* @param {HTMLVideoElement|Image} event.content
-			* @param {Boolean} event.isVideo
-			* @param {String} event.projectionType
-			*/
 		return this.trigger(name, evt);
 	}
 

--- a/src/PanoViewer/PanoViewer.js
+++ b/src/PanoViewer/PanoViewer.js
@@ -256,10 +256,6 @@ export default class PanoViewer extends Component {
 	}
 
 	_bindRendererHandler() {
-		this._photoSphereRenderer.on(PanoImageRenderer.EVENTS.IMAGE_LOADED, e => {
-			this.trigger(EVENTS.CONTENT_LOADED, e);
-		});
-
 		this._photoSphereRenderer.on(PanoImageRenderer.EVENTS.ERROR, e => {
 			this.trigger(EVENTS.ERROR, e);
 		});

--- a/src/PanoViewer/PanoViewer.js
+++ b/src/PanoViewer/PanoViewer.js
@@ -246,8 +246,7 @@ export default class PanoViewer extends Component {
 
 		this._photoSphereRenderer
 			.bindTexture()
-			.then(() => this._activate())
-			.catch(() => {
+			.then(() => this._activate(), () => {
 				this._triggerEvent(EVENTS.ERROR, {
 					type: ERROR_TYPE.FAIL_BIND_TEXTURE,
 					message: "failed to bind texture"

--- a/src/PanoViewer/PanoViewer.js
+++ b/src/PanoViewer/PanoViewer.js
@@ -623,13 +623,6 @@ export default class PanoViewer extends Component {
 			this._yawPitchControl.destroy();
 			this._yawPitchControl = null;
 		}
-
-		if (this._photoSphereRenderer) {
-			this._photoSphereRenderer.destroy();
-			this._photoSphereRenderer = null;
-		}
-
-		this._isReady = false;
 	}
 
 	static isWebGLAvailable() {

--- a/src/PanoViewer/consts.js
+++ b/src/PanoViewer/consts.js
@@ -13,8 +13,7 @@ const EVENTS = {
 	READY: "ready",
 	VIEW_CHANGE: "viewChange",
 	ANIMATION_END: "animationEnd",
-	ERROR: "error",
-	CONTENT_LOADED: "contentLoaded"
+	ERROR: "error"
 };
 
 const PROJECTION_TYPE = {

--- a/test/manual/PanoViewer/PanoVideo.html
+++ b/test/manual/PanoViewer/PanoVideo.html
@@ -56,18 +56,18 @@
   <script>
     var rootNode = document.querySelector(".photo360");
     var video;
+    var videoSrc = document.getElementById("videoSrc");
     var panoViewer = new eg.view360.PanoViewer(rootNode, {
-      video: document.getElementById("videoSrc"),
+      video: videoSrc,
       imageType: "equirectangular",
       controlMode: "gallery_yaw_pitch"
-    }).on("contentLoaded", function(e) {
-      video = e.content;
+    }).on("ready", function() {
       document.getElementById("play").addEventListener("click", function() {
-        video.play();
+        videoSrc.play();
       });
 
       document.getElementById("pause").addEventListener("click", function() {
-        video.pause();
+        videoSrc.pause();
       });
     });
 

--- a/test/unit/PanoImageRenderer/PanoImageRenderer.spec.js
+++ b/test/unit/PanoImageRenderer/PanoImageRenderer.spec.js
@@ -2,6 +2,7 @@ import PanoImageRenderer from "../../../src/PanoImageRenderer/PanoImageRenderer"
 import WebGLUtils from "../../../src/PanoImageRenderer/WebGLUtils";
 import PanoImageRendererInjector from "inject-loader!../../../src/PanoImageRenderer/PanoImageRenderer";
 import SphereRendererInjector from "inject-loader!../../../src/PanoImageRenderer/renderer/SphereRenderer";
+import TestHelper from "../YawPitchControl/testHelper";
 
 const SphereRendererOnIE11 = SphereRendererInjector(
 	{
@@ -1037,9 +1038,10 @@ describe("PanoImageRenderer", function() {
 				fieldOfView: 65
 			}, DEBUG_CONTEXT_ATTRIBUTES);
 
-			inst.on("imageLoaded", when);
+			// inst.on("imageLoaded", when); // 2018.02.26. imageLoaded does not gaurantee video is playable. (spec changed)
+			sourceImg.addEventListener("loadeddata", when);
 
-			function when() {
+			function when(e) {
 				// When
 				inst.bindTexture()
 					.then(() => {
@@ -1061,7 +1063,7 @@ describe("PanoImageRenderer", function() {
 			}
 		});
 
-        IT("yaw: 0, pitch:0, fov:65 : video IE11 change video size after loaded", function(done) {
+		IT("yaw: 0, pitch:0, fov:65 : video IE11 change video size after loaded", function(done) {
 			// Given
 			let inst = this.inst;
 			const sourceImg = document.createElement("video");
@@ -1078,13 +1080,14 @@ describe("PanoImageRenderer", function() {
 				fieldOfView: 65
 			}, DEBUG_CONTEXT_ATTRIBUTES);
 
-			inst.once("imageLoaded", onFirstLoad);
+			// inst.once("imageLoaded", onFirstLoad); // 2018.02.26. imageLoaded does not gaurantee video is playable. (spec changed)
+			TestHelper.once(sourceImg, "loadeddata", onFirstLoad)
 
 			function onFirstLoad() {
 				inst.bindTexture()
 				.then(() => {
 					// When
-					inst.once("imageLoaded", when);
+					TestHelper.once(sourceImg, "loadeddata", when);
 					sourceImg.src = "./images/test_equi.mp4";
 				});
 			}
@@ -1125,7 +1128,9 @@ describe("PanoImageRenderer", function() {
 				fieldOfView: 65
 			}, DEBUG_CONTEXT_ATTRIBUTES);
 
-			inst.on("imageLoaded", when);
+			// inst.on("imageLoaded", when); // 2018.02.26. imageLoaded does not gaurantee video is playable. (spec changed)
+			sourceImg.addEventListener("loadeddata", when);
+
 
 			function when() {
 				// When

--- a/test/unit/PanoViewer/PanoViewer.spec.js
+++ b/test/unit/PanoViewer/PanoViewer.spec.js
@@ -92,7 +92,7 @@ describe("PanoViewer", function() {
 				video: videlEl
 			}).on("ready", function() {
 				readyTriggered = true;
-				// then			
+				// then
 				expect(readyTriggered).to.be.true;
 				done();
 			});
@@ -107,7 +107,7 @@ describe("PanoViewer", function() {
 				video: videlEl
 			}).on("ready", function() {
 				readyTriggered = true;
-				// then			
+				// then
 				expect(readyTriggered).to.be.true;
 				done();
 			});
@@ -194,7 +194,7 @@ describe("PanoViewer", function() {
 			panoViewer.setVideo("./images/PanoViewer/pano.mp4");
 
 			// Then
-			panoViewer.on(PanoViewer.EVENTS.CONTENT_LOADED, e => {
+			panoViewer.on(PanoViewer.EVENTS.READY, e => {
 				const video = panoViewer.getVideo();
 				const projectionType = panoViewer.getProjectionType();
 
@@ -213,7 +213,7 @@ describe("PanoViewer", function() {
 			// Given
 			panoViewer = new PanoViewer(target, {
 				image: "./images/test_equi.png"
-			}).on(PanoViewer.EVENTS.CONTENT_LOADED, e => {
+			}).on(PanoViewer.EVENTS.READY, e => {
 				const image = panoViewer.getImage();
 
 				// When
@@ -267,16 +267,16 @@ describe("PanoViewer", function() {
 			// Given
 			panoViewer = new PanoViewer(target);
 
-			panoViewer.on(PanoViewer.EVENTS.CONTENT_LOADED, e => {
+			panoViewer.on(PanoViewer.EVENTS.READY, e => {
 				// Then
 				const image = panoViewer.getImage();
 				const projectionType = panoViewer.getProjectionType();
 
 				expect(image).to.not.be.null;
 				expect(projectionType).to.equal(PanoViewer.ProjectionType.EQUIRECTANGULAR);
-				expect(e.content).to.equal(image);
-				expect(e.projectionType).to.equal(projectionType);
-				expect(e.isVideo).to.be.false;
+				// expect(e.content).to.equal(image);
+				// expect(e.projectionType).to.equal(projectionType);
+				// expect(e.isVideo).to.be.false;
 				done();
 			});
 
@@ -298,14 +298,17 @@ describe("PanoViewer", function() {
 			});
 
 			// first `onContentLoad` event is for image specified in constructor.
-			panoViewer.once(PanoViewer.EVENTS.CONTENT_LOADED, evt1 => {
-				const prevContentSrc = evt1.content.src;
-				const prevProjectionType = evt1.projectionType;
+			panoViewer.once(PanoViewer.EVENTS.READY, evt1 => {
+				const prevContentSrc = panoViewer.getImage().src;
+				const prevProjectionType = panoViewer.getProjectionType();
 
-				panoViewer.once(PanoViewer.EVENTS.CONTENT_LOADED, evt2 => {
+				panoViewer.once(PanoViewer.EVENTS.READY, evt2 => {
+					const currContentSrc = panoViewer.getImage().src;
+					const currProjectionType = panoViewer.getProjectionType();
+
 					// Then
-					expect(evt2.content.src).to.not.equal(prevContentSrc);
-					expect(evt2.projectionType).to.not.equal(prevProjectionType);
+					expect(currContentSrc).to.not.equal(prevContentSrc);
+					expect(currProjectionType).to.not.equal(prevProjectionType);
 
 					done();
 				});
@@ -417,7 +420,6 @@ describe("PanoViewer", function() {
 				"ready": eventLogger,
 				"viewChange": eventLogger,
 				"animationEnd": eventLogger,
-				"contentLoaded": eventLogger,
 				"error": eventLogger
 			});
 
@@ -444,7 +446,6 @@ describe("PanoViewer", function() {
 
 		IT("should follow event order on create", function(done) {
 			var order = [
-				PanoViewer.EVENTS.CONTENT_LOADED,
 				PanoViewer.EVENTS.READY
 			];
 

--- a/test/unit/PanoViewer/PanoViewer.spec.js
+++ b/test/unit/PanoViewer/PanoViewer.spec.js
@@ -45,6 +45,8 @@ describe("PanoViewer", function() {
 		});
 
 		afterEach(() => {
+			cleanup();
+
 			if (!panoViewer) {
 				return;
 			}
@@ -179,6 +181,8 @@ describe("PanoViewer", function() {
 		});
 
 		afterEach(() => {
+			cleanup();
+
 			if (!panoViewer) {
 				return;
 			}
@@ -256,6 +260,8 @@ describe("PanoViewer", function() {
 		});
 
 		afterEach(() => {
+			cleanup();
+
 			if (!panoViewer) {
 				return;
 			}
@@ -322,6 +328,51 @@ describe("PanoViewer", function() {
 		});
 	});
 
+	describe("#lookAt", function() {
+		let target;
+
+		beforeEach(() => {
+			target = sandbox();
+			target.innerHTML = `<div></div>`;
+		});
+
+		afterEach(() => {
+			cleanup();
+		});
+
+		IT("should 'lookAt' works after ready event", done => {
+			// Given
+			const FIRST_REQ_DIR = {yaw: 10, pitch: 10};
+			const SECOND_REQ_DIR = {yaw: 20, pitch: 20};
+			const panoViewer = new PanoViewer(target, {
+				image: "./images/test_equi.png"
+			});
+
+			// When
+			const firstDir = {yaw: panoViewer.getYaw(), pitch:panoViewer.getPitch()};
+
+			panoViewer.lookAt(FIRST_REQ_DIR, 0);
+			const dir1 = {yaw: panoViewer.getYaw(), pitch:panoViewer.getPitch()};
+
+			panoViewer.on(PanoViewer.EVENTS.READY, e => {
+				panoViewer.lookAt(SECOND_REQ_DIR, 0);
+				const dir2 = {yaw: panoViewer.getYaw(), pitch:panoViewer.getPitch()};
+
+				// Then
+				expect(dir1.yaw).to.equal(firstDir.yaw);
+				expect(dir1.pitch).to.equal(firstDir.pitch);
+
+				expect(dir1.yaw).to.not.equal(FIRST_REQ_DIR.yaw);
+				expect(dir1.pitch).to.not.equal(FIRST_REQ_DIR.pitch);
+
+				expect(dir2.yaw).to.equal(SECOND_REQ_DIR.yaw);
+				expect(dir2.pitch).to.equal(SECOND_REQ_DIR.pitch);
+
+				done();
+			});
+		});
+	});
+
 	describe("viewChange event", function() {
 		let target;
 		let panoViewer;
@@ -332,6 +383,8 @@ describe("PanoViewer", function() {
 		});
 
 		afterEach(() => {
+			cleanup();
+
 			if (!panoViewer) {
 				return;
 			}
@@ -404,6 +457,8 @@ describe("PanoViewer", function() {
 		});
 
 		afterEach(() => {
+			cleanup();
+
 			if (!photo360Viewer) {
 				return;
 			}

--- a/test/unit/YawPitchControl/testHelper.js
+++ b/test/unit/YawPitchControl/testHelper.js
@@ -76,7 +76,7 @@ export default class TestHelper {
 		return new Promise((resolve) => {
 			const params = value;
 			let deviceMotionEvent;
-	
+
 			try {
 				deviceMotionEvent = new DeviceMotionEvent("devicemotion", params);
 			} catch (e) {
@@ -84,13 +84,13 @@ export default class TestHelper {
 				deviceMotionEvent.initEvent("devicemotion");
 				Object.assign(deviceMotionEvent, params);
 			}
-	
+
 			function callbackOnce() {
 				callback && callback();
 				resolve();
 				target.removeEventListener("devicemotion", callbackOnce);
 			}
-	
+
 			target.addEventListener("devicemotion", callbackOnce);
 			target.dispatchEvent(deviceMotionEvent);
 		});
@@ -145,6 +145,15 @@ export default class TestHelper {
 		}
 
 		loop();
+	}
+
+	static once(target, type, listener) {
+		const fn = event => {
+			target.removeEventListener(type, fn);
+			listener(event);
+		};
+
+		target.addEventListener(type, fn);
 	}
 }
 


### PR DESCRIPTION
## Issue
#156 

## Details
contentLoaded event is removed from "PanoViewer". It can be replaced with "ready" event.

But I didn't remove imageLoaded event from PanoImageRenderer
  - Because it is useful to get to know the timing of loading complete for multiple images.(cube images)