### PR TITLE
feat(PanoViewer): support big size image than texture

### DIFF
--- a/src/PanoImageRenderer/WebGLUtils.js
+++ b/src/PanoImageRenderer/WebGLUtils.js
@@ -177,14 +177,18 @@ export default class WebGLUtils {
 		// WARN: MAX_TEXTURE_SIZE_FOR_TEST is used for test
 		return MAX_TEXTURE_SIZE_FOR_TEST || gl.getParameter(gl.MAX_TEXTURE_SIZE);
 	}
-
-	/**
-	 * This function should not be used in service code. It's provided only for test purpose.
-	 * It should be set to null or 0 when test is done.
-	 *
-	 * @param {Number} size
-	 */
-	static setMaxTextureSizeForTestOnlyPurpose(size) {
-		MAX_TEXTURE_SIZE_FOR_TEST = size;
-	}
 }
+
+/**
+ * This function should not be used in service code. It's provided only for test purpose.
+ * It should be set to null or 0 when test is done.
+ *
+ * @param {Number} size
+ */
+function setMaxTextureSizeForTestOnlyPurpose(size) {
+	MAX_TEXTURE_SIZE_FOR_TEST = size;
+}
+
+export {
+	setMaxTextureSizeForTestOnlyPurpose
+};

--- a/src/PanoImageRenderer/WebGLUtils.js
+++ b/src/PanoImageRenderer/WebGLUtils.js
@@ -11,6 +11,7 @@ const WEBGL_ERROR_CODE = {
 };
 
 let webglAvailability = null;
+let MAX_TEXTURE_SIZE_FOR_TEST = null;
 
 export default class WebGLUtils {
 	static createShader(gl, type, source) {
@@ -170,5 +171,20 @@ export default class WebGLUtils {
 			console.error("WebGLUtils.texImage2D error:", error);
 			/* eslint-enable no-console */
 		}
+	}
+
+	static getMaxTextureSize(gl) {
+		// WARN: MAX_TEXTURE_SIZE_FOR_TEST is used for test
+		return MAX_TEXTURE_SIZE_FOR_TEST || gl.getParameter(gl.MAX_TEXTURE_SIZE);
+	}
+
+	/**
+	 * This function should not be used in service code. It's provided only for test purpose.
+	 * It should be set to null or 0 when test is done.
+	 *
+	 * @param {Number} size
+	 */
+	static setMaxTextureSizeForTestOnlyPurpose(size) {
+		MAX_TEXTURE_SIZE_FOR_TEST = size;
 	}
 }

--- a/src/PanoImageRenderer/renderer/CubeStripRenderer.js
+++ b/src/PanoImageRenderer/renderer/CubeStripRenderer.js
@@ -189,7 +189,7 @@ export default class CubeStripRenderer extends Renderer {
 		// Make sure image isn't too big
 		const {width, height} = this.getDimension(image);
 		const size = Math.max(width, height);
-		const maxSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
+		const maxSize = WebGLUtils.getMaxTextureSize(gl);
 
 		if (size > maxSize) {
 			this._triggerError(`Image width(${width}) exceeds device limit(${maxSize}))`);

--- a/src/PanoImageRenderer/renderer/CylinderRenderer.js
+++ b/src/PanoImageRenderer/renderer/CylinderRenderer.js
@@ -60,15 +60,23 @@ export default class CylinderRenderer extends Renderer {
 		// Make sure image isn't too big
 		const {width, height} = this.getDimension(image);
 		const size = Math.max(width, height);
-		const maxSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
+		const maxSize = WebGLUtils.getMaxTextureSize(gl);
+		let resizeDimension;
 
 		if (size > maxSize) {
-			this._triggerError(`Image width(${width}) exceeds device limit(${maxSize}))`);
-			return;
+			this._triggerError(`Image width(${width}) exceeds device texture limit(${maxSize}))`);
+
+			// Request resizing texture.
+			/**
+			 * TODO: Is it need to apply on another projection type?
+			 */
+			resizeDimension = width > height ?
+				{width: maxSize, height: maxSize * height / width} :
+				{width: maxSize * width / height, height: maxSize};
 		}
 
-		// Pixel Source for IE11 & Video
-		this._initPixelSource(image);
+		// Pixel Source for IE11 & Video or resizing needed
+		this._initPixelSource(image, resizeDimension);
 
 		gl.activeTexture(gl.TEXTURE0);
 		gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);

--- a/src/PanoImageRenderer/renderer/SphereRenderer.js
+++ b/src/PanoImageRenderer/renderer/SphereRenderer.js
@@ -88,7 +88,7 @@ export default class SphereRenderer extends Renderer {
 		// Make sure image isn't too big
 		const {width, height} = this.getDimension(image);
 		const size = Math.max(width, height);
-		const maxSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
+		const maxSize = WebGLUtils.getMaxTextureSize(gl);
 
 		if (size > maxSize) {
 			this._triggerError(`Image width(${width}) exceeds device limit(${maxSize}))`);

--- a/test/unit/PanoImageRenderer/CubeStripRenderer.spec.js
+++ b/test/unit/PanoImageRenderer/CubeStripRenderer.spec.js
@@ -11,7 +11,7 @@ describe("CubeStripRenderer", () => {
 			// Given
 			const canvas = document.createElement("canvas");
 			const gl = WebGLUtils.getWebglContext(canvas);
-			const MAX_SIZE = gl.getParameter(gl.MAX_TEXTURE_SIZE);
+			const MAX_SIZE = WebGLUtils.getMaxTextureSize(gl);
 			const cubeRenderer = new CubeStripRenderer();
 
 			cubeRenderer.on(Renderer.EVENTS.ERROR, then);

--- a/test/unit/PanoImageRenderer/CylinderRenderer.spec.js
+++ b/test/unit/PanoImageRenderer/CylinderRenderer.spec.js
@@ -148,6 +148,37 @@ describe("CylinderRenderer", () => {
 		});
 	});
 
+	describe("Big image over texture limit", () => {
+		beforeEach(() => {
+			WebGLUtils.setMaxTextureSizeForTestOnlyPurpose(4096);
+		});
+
+		afterEach(() => {
+			WebGLUtils.setMaxTextureSizeForTestOnlyPurpose(null);
+		});
+
+		IT("If image is bigger than texture size, than image size should be resized below the texture size.", async () => {
+			// Given
+			// When
+			/**
+			 * If Panorama is rotated
+			 */
+			const renderer = createPanoImageRenderer("./images/PanoViewer/Panorama/smartphone-panorama-picture.jpg", false, PROJECTION_TYPE.PANORAMA, {});
+
+			await renderer.bindTexture();
+
+			const projRenderer = renderer.getProjectionRenderer();
+			const maxSize = WebGLUtils.getMaxTextureSize(); // param 'gl' can be absent when test mode
+			const content = projRenderer._getPixelSource(renderer.getContent());
+
+			// Then
+			// Image should be converted to canvas.
+			expect(content instanceof HTMLCanvasElement).to.be.equal(true);
+			expect(content.width <= maxSize).to.be.ok;
+			expect(content.height <= maxSize).to.be.ok;
+		})
+	});
+
 	describe("PanoViewer Test", () => {
 		let target;
 		let viewer;

--- a/test/unit/PanoImageRenderer/CylinderRenderer.spec.js
+++ b/test/unit/PanoImageRenderer/CylinderRenderer.spec.js
@@ -1,6 +1,6 @@
 import {createPanoImageRenderer, renderAndCompareSequentially, calcFovOfPanormaImage} from "../util";
 import PanoViewer from "../../../src/PanoViewer/PanoViewer";
-import WebGLUtils from "../../../src/PanoImageRenderer/WebGLUtils";
+import WebGLUtils, {setMaxTextureSizeForTestOnlyPurpose} from "../../../src/PanoImageRenderer/WebGLUtils";
 import {PROJECTION_TYPE} from "../../../src/PanoViewer/consts";
 import CylinderRenderer from "../../../src/PanoImageRenderer/renderer/CylinderRenderer";
 import {glMatrix} from "../../../src/utils/math-util.js";
@@ -150,11 +150,11 @@ describe("CylinderRenderer", () => {
 
 	describe("Big image over texture limit", () => {
 		beforeEach(() => {
-			WebGLUtils.setMaxTextureSizeForTestOnlyPurpose(4096);
+			setMaxTextureSizeForTestOnlyPurpose(4096);
 		});
 
 		afterEach(() => {
-			WebGLUtils.setMaxTextureSizeForTestOnlyPurpose(null);
+			setMaxTextureSizeForTestOnlyPurpose(null);
 		});
 
 		IT("If image is bigger than texture size, than image size should be resized below the texture size.", async () => {

--- a/test/unit/PanoImageRenderer/SphereRenderer.spec.js
+++ b/test/unit/PanoImageRenderer/SphereRenderer.spec.js
@@ -11,7 +11,7 @@ describe("SphereRenderer", () => {
 			// Given
 			const canvas = document.createElement("canvas");
 			const gl = WebGLUtils.getWebglContext(canvas);
-			const MAX_SIZE = gl.getParameter(gl.MAX_TEXTURE_SIZE);
+			const MAX_SIZE = WebGLUtils.getMaxTextureSize(gl);
 			const cubeRenderer = new SphereRenderer();
 
 			cubeRenderer.on(Renderer.EVENTS.ERROR, then);


### PR DESCRIPTION
## Issue
Ref #233

## Details
If the image is bigger than texture size, than resize image using canvas and bindTexture with that canvas.

**Only applied on Cylinder Renderer**