### PR TITLE
Bundle promise polyfill for IE11

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -16,7 +16,7 @@
         "transform-es3-property-literals",
         "transform-es3-member-expression-literals",
         "transform-object-assign",
-        "es6-promise"
+        "es6-promise-esm"
     ]
 }
 

--- a/demo/common/css/demo.css
+++ b/demo/common/css/demo.css
@@ -13,7 +13,7 @@ header {
 header h1 {
   font-family: 'Zilla Slab', serif;
   font-weight: bold;
-  margin: 30px 0;
+  margin: 45px 0 30px;
   text-align: center;
   font-size: 60px;
   word-break: break-word;
@@ -220,3 +220,28 @@ p.info img {
   border: 0;
   background-size: 100% 100%;
 }
+
+  header .home {
+    margin: 0;
+    font-size: 26px;
+    background-repeat: no-repeat;
+    width: 198px;
+    height: 27px;
+    position: absolute;
+    text-align: left;
+  }
+  
+  .home img.egjs_logo{
+    width: 34px;
+    display: block;
+    margin-bottom: -8px;
+  }
+
+  .home a {
+    font-family: 'Zilla Slab', serif;
+    line-height: 40px;
+    letter-spacing: -0.8px;
+    text-decoration: none;
+    display: inline-block;
+    color: #2B2B2B;
+  }

--- a/demo/examples/panoviewer/controls/change_direction.html
+++ b/demo/examples/panoviewer/controls/change_direction.html
@@ -21,6 +21,12 @@
 
 <body>
     <header>
+        <div class="home">
+            <a href="../../../panoviewer.html">
+                <img class="egjs_logo" src="./../../../common/img/type_black.svg">
+                PanoViewer
+            </a><!--//logo-->
+        </div>
         <h1>Change direction</h1>
         <div class="infos">
             <p class="info">

--- a/demo/examples/panoviewer/controls/custom-control.html
+++ b/demo/examples/panoviewer/controls/custom-control.html
@@ -113,6 +113,12 @@
 </head>
 <body>
     <header>
+        <div class="home">
+            <a href="../../../panoviewer.html">
+                <img class="egjs_logo" src="./../../../common/img/type_black.svg">
+                PanoViewer
+            </a><!--//logo-->
+        </div>
         <h1>Custom Control</h1>
         <div class="icon">
             <svg class="feather feather-chevron-left sc-dnqmqq jxshSx" xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="15 18 9 12 15 6"></polyline></svg>

--- a/demo/examples/panoviewer/controls/doc-embeded.html
+++ b/demo/examples/panoviewer/controls/doc-embeded.html
@@ -99,6 +99,12 @@
 </head>
 <body>
     <header>
+      <div class="home">
+          <a href="../../../panoviewer.html">
+              <img class="egjs_logo" src="./../../../common/img/type_black.svg">
+              PanoViewer
+          </a><!--//logo-->
+      </div>
       <h1>Document Embeded - Scroll</h1>
       <div class="icon">
         <p></p>

--- a/demo/examples/panoviewer/controls/keyboard-wheel.html
+++ b/demo/examples/panoviewer/controls/keyboard-wheel.html
@@ -144,6 +144,12 @@
 
 <body>
     <header>
+        <div class="home">
+            <a href="../../../panoviewer.html">
+                <img class="egjs_logo" src="./../../../common/img/type_black.svg">
+                PanoViewer
+            </a><!--//logo-->
+        </div>
         <h1>Direction key & Wheel Zoom</h1>
         <ul class="icon">
             <li class="input-item WheelInput">

--- a/demo/examples/panoviewer/controls/motion-touch.html
+++ b/demo/examples/panoviewer/controls/motion-touch.html
@@ -92,6 +92,12 @@
 </head>
 <body>
     <header>
+        <div class="home">
+            <a href="../../../panoviewer.html">
+                <img class="egjs_logo" src="./../../../common/img/type_black.svg">
+                PanoViewer
+            </a><!--//logo-->
+        </div>
         <h1>Device Motion (Gyro Mode) & Touch</h1>
         <div class="icon">
             <div class="phone"></div>

--- a/demo/examples/panoviewer/controls/setting_initial_view.html
+++ b/demo/examples/panoviewer/controls/setting_initial_view.html
@@ -14,6 +14,12 @@
 
 <body>
     <header>
+        <div class="home">
+            <a href="../../../panoviewer.html">
+                <img class="egjs_logo" src="./../../../common/img/type_black.svg">
+                PanoViewer
+            </a><!--//logo-->
+        </div>
         <h1>Setting the initial view</h1>
         <div class="infos">
             <p class="info">

--- a/demo/examples/panoviewer/etc/hotspot.html
+++ b/demo/examples/panoviewer/etc/hotspot.html
@@ -218,6 +218,12 @@
 <body>
 <div class="qrcode"></div>
 <header>
+    <div class="home">
+        <a href="../../../panoviewer.html">
+            <img class="egjs_logo" src="./../../../common/img/type_black.svg">
+            PanoViewer
+        </a><!--//logo-->
+    </div>
     <h1>HotSpot</h1>
     <div class="icon">
         <div class="earth">

--- a/demo/examples/panoviewer/etc/loading_indicator.html
+++ b/demo/examples/panoviewer/etc/loading_indicator.html
@@ -66,6 +66,12 @@
 
 <body>
     <header>
+        <div class="home">
+            <a href="../../../panoviewer.html">
+                <img class="egjs_logo" src="./../../../common/img/type_black.svg">
+                PanoViewer
+            </a><!--//logo-->
+        </div>
         <h1>view360 with Loading Indicator</h1>
         <div class="icon">
             <span class="dot"></span><span class="dot"></span><span class="dot"></span>

--- a/demo/examples/panoviewer/etc/partial_panorama.html
+++ b/demo/examples/panoviewer/etc/partial_panorama.html
@@ -58,6 +58,12 @@
 
 <body>
     <header>
+        <div class="home">
+            <a href="../../../panoviewer.html">
+                <img class="egjs_logo" src="./../../../common/img/type_black.svg">
+                PanoViewer
+            </a><!--//logo-->
+        </div>
         <h1>360 Image<br/>(partial 270°)</h1>  
         <div class="icon">
             <div class="d180"></div>

--- a/demo/examples/panoviewer/etc/responsive.html
+++ b/demo/examples/panoviewer/etc/responsive.html
@@ -133,6 +133,12 @@
 
 <body>
     <header>
+        <div class="home">
+            <a href="../../../panoviewer.html">
+                <img class="egjs_logo" src="./../../../common/img/type_black.svg">
+                PanoViewer
+            </a><!--//logo-->
+        </div>
         <h1>Responsive</h1>
         <div class="icon">
             <div class="resizer">

--- a/demo/examples/panoviewer/etc/synchronize.html
+++ b/demo/examples/panoviewer/etc/synchronize.html
@@ -21,6 +21,12 @@
 </head>
 <body>
   <header>
+    <div class="home">
+        <a href="../../../panoviewer.html">
+            <img class="egjs_logo" src="./../../../common/img/type_black.svg">
+            PanoViewer
+        </a><!--//logo-->
+    </div>
     <h1>Synchronize</h1>
   </header>
   <h2>Synchronize the directions of the two contents.</h2>

--- a/demo/examples/panoviewer/etc/videojs.html
+++ b/demo/examples/panoviewer/etc/videojs.html
@@ -101,6 +101,12 @@
 
 <body>
 <header>
+    <div class="home">
+        <a href="../../../panoviewer.html">
+            <img class="egjs_logo" src="./../../../common/img/type_black.svg">
+            PanoViewer
+        </a><!--//logo-->
+    </div>
     <h1>Video.js with view360</h1>
     <div class="icon">
         <div class="videojs">

--- a/demo/examples/panoviewer/projection-type/cubemap_image.html
+++ b/demo/examples/panoviewer/projection-type/cubemap_image.html
@@ -16,6 +16,12 @@
 
 <body>
     <header>
+        <div class="home">
+            <a href="../../../panoviewer.html">
+                <img class="egjs_logo" src="./../../../common/img/type_black.svg">
+                PanoViewer
+            </a><!--//logo-->
+        </div>
         <h1>3x2 Cubemap</h1>
     </header>
     <h2>Support variety cubemap format</h2>

--- a/demo/examples/panoviewer/projection-type/cubemap_video.html
+++ b/demo/examples/panoviewer/projection-type/cubemap_video.html
@@ -15,6 +15,12 @@
 
 <body>
     <header>
+        <div class="home">
+            <a href="../../../panoviewer.html">
+                <img class="egjs_logo" src="./../../../common/img/type_black.svg">
+                PanoViewer
+            </a><!--//logo-->
+        </div>
         <h1>Cubemap 3 x 2 Video </h1>
     </header>
     <h2>Support variety cubemap format</h2>

--- a/demo/examples/panoviewer/projection-type/cubestrip_3x2_image.html
+++ b/demo/examples/panoviewer/projection-type/cubestrip_3x2_image.html
@@ -15,6 +15,12 @@
 
 <body>
     <header>
+        <div class="home">
+            <a href="../../../panoviewer.html">
+                <img class="egjs_logo" src="./../../../common/img/type_black.svg">
+                PanoViewer
+            </a><!--//logo-->
+        </div>
         <h1>3x2 CubeStrip Image</h1>
     </header>
     <h2>Support variety cubestrip format</h2>

--- a/demo/examples/panoviewer/projection-type/equirectangular_image.html
+++ b/demo/examples/panoviewer/projection-type/equirectangular_image.html
@@ -16,6 +16,12 @@
 
 <body>
     <header>
+        <div class="home">
+            <a href="../../../panoviewer.html">
+                <img class="egjs_logo" src="./../../../common/img/type_black.svg">
+                PanoViewer
+            </a><!--//logo-->
+        </div>
         <h1>Equirectangular Image</h1>
     </header>
     <h2>Supports the most common 360 formats.</h2>

--- a/demo/examples/panoviewer/projection-type/equirectangular_video.html
+++ b/demo/examples/panoviewer/projection-type/equirectangular_video.html
@@ -15,6 +15,12 @@
 
 <body>
     <header>
+        <div class="home">
+            <a href="../../../panoviewer.html">
+                <img class="egjs_logo" src="./../../../common/img/type_black.svg">
+                PanoViewer
+            </a><!--//logo-->
+        </div>
         <h1>Video Tag (Equirectangular)</h1>  
     </header>
     <h2>Loads video by video tag</h2>

--- a/demo/examples/panoviewer/projection-type/equirectangular_video_url.html
+++ b/demo/examples/panoviewer/projection-type/equirectangular_video_url.html
@@ -20,6 +20,12 @@
 
 <body>
     <header>
+        <div class="home">
+            <a href="../../../panoviewer.html">
+                <img class="egjs_logo" src="./../../../common/img/type_black.svg">
+                PanoViewer
+            </a><!--//logo-->
+        </div>
         <h1>Video URL (Equirectangular)</h1>
     </header>
     <h2>Loads video by URL</h2>

--- a/demo/examples/panoviewer/projection-type/panorama_image.html
+++ b/demo/examples/panoviewer/projection-type/panorama_image.html
@@ -18,6 +18,12 @@
 
 <body>
     <header>
+        <div class="home">
+            <a href="../../../panoviewer.html">
+                <img class="egjs_logo" src="./../../../common/img/type_black.svg">
+                PanoViewer
+            </a><!--//logo-->
+        </div>
         <h1>Smartphone Panorama</h1>
     </header>
     <!--https://icons8.com/icon/set/panorama-view/ios-->

--- a/demo/examples/panoviewer/projection-type/stereoequi.html
+++ b/demo/examples/panoviewer/projection-type/stereoequi.html
@@ -12,6 +12,12 @@
 </head>
 <body>
     <header>
+        <div class="home">
+            <a href="../../../panoviewer.html">
+                <img class="egjs_logo" src="./../../../common/img/type_black.svg">
+                PanoViewer
+            </a><!--//logo-->
+        </div>
         <h1>Stereoscopic</h1>
     </header>
     <!-- <div class="icon" style='background-image: url("./img/stereoequi.png");background-size:100px'> -->

--- a/demo/examples/panoviewer/projection-type/verticalcubestrip_image.html
+++ b/demo/examples/panoviewer/projection-type/verticalcubestrip_image.html
@@ -21,6 +21,12 @@
 
 <body>
     <header>
+        <div class="home">
+            <a href="../../../panoviewer.html">
+                <img class="egjs_logo" src="./../../../common/img/type_black.svg">
+                PanoViewer
+            </a><!--//logo-->
+        </div>
         <h1>Customized Cubemap</h1>
     </header>
 

--- a/demo/examples/panoviewer/projection-type/youtube.html
+++ b/demo/examples/panoviewer/projection-type/youtube.html
@@ -17,6 +17,12 @@
 </head>
 <body>
     <header>
+        <div class="home">
+            <a href="../../../panoviewer.html">
+                <img class="egjs_logo" src="./../../../common/img/type_black.svg">
+                PanoViewer
+            </a><!--//logo-->
+        </div>
         <h1>Youtube (EAC Format)</h1>
     </header>
     <div class="icon">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@egjs/view360",
-  "version": "3.2.0-rc",
+  "version": "3.2.0-snapshot",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4700,10 +4700,10 @@
         "babel-runtime": "^6.22.0"
       }
     },
-    "babel-plugin-es6-promise": {
+    "babel-plugin-es6-promise-esm": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-es6-promise/-/babel-plugin-es6-promise-1.1.1.tgz",
-      "integrity": "sha1-AgLwkpcF8v3N2o/9EiIkbCy51q4=",
+      "resolved": "https://registry.npmjs.org/babel-plugin-es6-promise-esm/-/babel-plugin-es6-promise-esm-1.1.1.tgz",
+      "integrity": "sha512-CuFSbPhrYdTo8LrGei5p5sloOr+wiOS3C6ZmZTT5GiitOaDlpt7wjdnJS4XODozxigClSZqE+Tvep1XRIEfNyw==",
       "dev": true,
       "requires": {
         "babel-template": "^6.7.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 		"babel-eslint": "^10.0.1",
 		"babel-loader": "^8.0.4",
 		"babel-plugin-add-module-exports": "^0.2.1",
-		"babel-plugin-es6-promise": "^1.1.1",
+		"babel-plugin-es6-promise-esm": "^1.1.1",
 		"babel-plugin-no-side-effect-class-properties": "0.0.4",
 		"babel-plugin-transform-es3-member-expression-literals": "^6.22.0",
 		"babel-plugin-transform-es3-property-literals": "^6.22.0",


### PR DESCRIPTION
## Issue
Ref #272

## Details
  - It's omitted at 3.2.0 release by changing bundler from webpack to rollup.
  - Because `babel-plugin-es6-promise` use `require` for importing module. but rollup does not change it.
   - So change `babel-plugin-es6-promise` to use `import` for importing moulde.

