### PR TITLE
chore(demo): fix typo in PanoViewer hotstpot demo

### DIFF
--- a/demo/examples/panoviewer/etc/hotspot.html
+++ b/demo/examples/panoviewer/etc/hotspot.html
@@ -264,7 +264,7 @@
     </div>
     <div class="hotspot search" data-page="2" data-anchor-index="0" data-yaw="-60" data-pitch="-23" onclick="openLayer('book4.jpg')"></div>
     <div class="hotspot link" data-page="2" data-anchor-index="1" data-yaw="80" data-pitch="-12" onclick="load(this, 1)">
-        Technowlogy<br />Science
+        Technology<br />Science
     </div>
 </div>
 <div class="source">


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
None

## Details
<!-- Detailed description of the change/feature -->
Hello, I was watching the demo and caught a tiny typo in the panoviewer hotspot demo.
So I changed `technowlogy` to `technology`.