### PR TITLE
docs: fix v3 demo link

### DIFF
--- a/demo/docs/tutorials/Installation.mdx
+++ b/demo/docs/tutorials/Installation.mdx
@@ -24,7 +24,7 @@ npm install @egjs/view360@latest
 ```
 
 Looking for the documents of the previous version? Check these documents:
-- [Demo (v3)](https://naver.github.io/egjs-view360/release/3.6.4/)
+- [Demo (v3)](https://naver.github.io/egjs-view360/v3/)
 - [API (v3)](https://naver.github.io/egjs-view360/release/3.6.4/doc/)
 :::
 

--- a/demo/i18n/ko/docusaurus-plugin-content-docs/current/tutorials/Installation.mdx
+++ b/demo/i18n/ko/docusaurus-plugin-content-docs/current/tutorials/Installation.mdx
@@ -23,7 +23,7 @@ npm install @egjs/view360@latest
 ```
 
 기존 버젼의 문서를 찾고 계신가요? 아래 링크들을 확인해보세요:
-- [Demo (v3)](https://naver.github.io/egjs-view360/release/3.6.4/)
+- [Demo (v3)](https://naver.github.io/egjs-view360/v3/)
 - [API (v3)](https://naver.github.io/egjs-view360/release/3.6.4/doc/)
 :::
 


### PR DESCRIPTION
## Details
This fixes the wrong link to the v3 demo in our current demo