### PR TITLE
fix: low performance due to proxy wrapping

### DIFF
--- a/demo/docs/tutorials/Migration/v4.mdx
+++ b/demo/docs/tutorials/Migration/v4.mdx
@@ -355,7 +355,7 @@ const { min, max } = viewer.camera.getYawRange(viewer.camera.zoom);
 - Deleted.
 
 ### getImage, getVideo
-- It can be replaced by `getTexture()` of View360.
+- It can be replaced by `getTexture()` of View360.mesh.
 
 > v3
 
@@ -366,7 +366,7 @@ const image = viewer.getImage();
 > v4
 
 ```js
-const image = viewer.getTexture().source;
+const image = viewer.mesh.getTexture().source;
 ```
 
 ### keepUpdate

--- a/demo/i18n/ko/docusaurus-plugin-content-docs/current/tutorials/Migration/v4.mdx
+++ b/demo/i18n/ko/docusaurus-plugin-content-docs/current/tutorials/Migration/v4.mdx
@@ -356,7 +356,7 @@ const { min, max } = viewer.camera.getYawRange(viewer.camera.zoom);
 - 삭제되었습니다.
 
 ### getImage, getVideo
-- View360의 `getTexture()`로 대체 가능합니다.
+- View360.mesh의 `getTexture()`로 대체 가능합니다.
 
 > 기존
 
@@ -367,7 +367,7 @@ const image = viewer.getImage();
 > 변경
 
 ```js
-const image = viewer.getTexture().source;
+const image = viewer.mesh.getTexture().source;
 ```
 
 ### keepUpdate

--- a/packages/view360/src/const/internal.ts
+++ b/packages/view360/src/const/internal.ts
@@ -10,6 +10,10 @@ export const CAMERA_EVENTS = {
   ANIMATION_END: "animationEnd"
 } as const;
 
+export const OBJECT_3D_EVENTS = {
+  UPDATE: "update"
+} as const;
+
 export const CONTROL_EVENTS = {
   INPUT_START: "inputStart",
   CHANGE: "change",

--- a/packages/view360/src/core/Object3D.ts
+++ b/packages/view360/src/core/Object3D.ts
@@ -2,7 +2,18 @@
  * Copyright (c) 2023-present NAVER Corp.
  * egjs projects are licensed under the MIT license
  */
+import Component from "@egjs/component";
 import { mat4, quat, vec3 } from "gl-matrix";
+import { OBJECT_3D_EVENTS } from "../const/internal";
+import Camera from "./Camera";
+
+/**
+ * Context interface used for object update
+ * @internal
+ */
+interface ObjectUpdateContext {
+  camera: Camera;
+}
 
 /**
  * Base class for 3D objects
@@ -10,7 +21,11 @@ import { mat4, quat, vec3 } from "gl-matrix";
  * @since 4.0.0
  * @internal
  */
-class Object3D {
+class Object3D extends Component<{
+  [OBJECT_3D_EVENTS.UPDATE]: {
+    camera: Camera
+  };
+}> {
   /**
    * Local matrix of the object
    * @ko 오브젝트의 local matrix
@@ -41,6 +56,8 @@ class Object3D {
    * @ko 새로운 인스턴스를 생성합니다.
    */
   public constructor() {
+    super();
+
     this.matrix = mat4.create();
     this.rotation = quat.create();
     this.position = vec3.fromValues(0, 0, 0);
@@ -54,6 +71,10 @@ class Object3D {
    */
   public updateMatrix() {
     mat4.fromRotationTranslationScale(this.matrix, this.rotation, this.position, this.scale);
+  }
+
+  public update(ctx: ObjectUpdateContext) {
+    this.trigger(OBJECT_3D_EVENTS.UPDATE, ctx);
   }
 }
 

--- a/packages/view360/src/core/TriangleMesh.ts
+++ b/packages/view360/src/core/TriangleMesh.ts
@@ -5,13 +5,19 @@
 import Object3D from "./Object3D";
 import ShaderProgram from "./ShaderProgram";
 import VertexArrayObject from "./VertexArrayObject";
-import Uniform from "../uniform/Uniform";
 import WebGLContext from "./WebGLContext";
+import UniformCanvasCube from "../uniform/UniformCanvasCube";
+import UniformTexture2D from "../uniform/UniformTexture2D";
+import UniformTextureCube from "../uniform/UniformTextureCube";
+
+type CommonProjectionUniforms = {
+  uTexture: UniformTexture2D | UniformTextureCube | UniformCanvasCube;
+}
 
 /**
  * @hidden
  */
-class TriangleMesh<T extends Record<string, Uniform> = Record<string, never>> extends Object3D {
+class TriangleMesh<T extends CommonProjectionUniforms = CommonProjectionUniforms> extends Object3D {
   /**
    * @internal
    * Geometry data for projection
@@ -33,6 +39,10 @@ class TriangleMesh<T extends Record<string, Uniform> = Record<string, never>> ex
   public destroy(ctx: WebGLContext) {
     ctx.releaseVAO(this.vao);
     ctx.releaseShaderResources(this.program);
+  }
+
+  public getTexture() {
+    return this.program.uniforms.uTexture.texture;
   }
 }
 

--- a/packages/view360/src/core/WebGLRenderer.ts
+++ b/packages/view360/src/core/WebGLRenderer.ts
@@ -4,9 +4,9 @@
  */
 import { mat4 } from "gl-matrix";
 import Camera from "./Camera";
-import Projection from "../projection/Projection";
 import WebGLContext from "./WebGLContext";
 import XRManager from "./XRManager";
+import TriangleMesh from "./TriangleMesh";
 
 /**
  * Projection renderer, based on WebGL
@@ -113,15 +113,14 @@ class WebGLRenderer {
    * @param cameraa - Camera instance {@ko 카메라의 인스턴스}
    * @since 4.0.0
    */
-  public render(projection: Projection, camera: Camera) {
+  public render(mesh: TriangleMesh, camera: Camera) {
     const ctx = this.ctx;
-    const mesh = projection.getMesh();
-    if (ctx.lost || !mesh) return;
+    if (ctx.lost) return;
 
     ctx.clear();
     ctx.useProgram(mesh.program);
     ctx.updateCommonUniforms(mesh, camera, mesh.program);
-    projection.update(camera);
+    mesh.update({ camera });
     ctx.updateUniforms(mesh.program);
     ctx.draw(mesh.vao, mesh.program);
   }
@@ -130,14 +129,13 @@ class WebGLRenderer {
    * Render VR frame, only used for rendering frames inside VR sessions.
    * @ko VR 프레임을 렌더링합니다. VR 세션 진입 도중에만 사용됩니다.
    * @internal
-   * @param projection - Projection to render {@ko 렌더링할 프로젝션}
+   * @param mesh - Triangle mesh to render {@ko 렌더링할 메쉬}
    * @param vr - Instance of XRManager {@ko XRManager의 인스턴스}
    * @param frame - VR frame {@ko VR 프레임}
    * @since 4.0.0
    */
-  public renderVR(projection: Projection, vr: XRManager, frame: XRFrame) {
+  public renderVR(mesh: TriangleMesh, vr: XRManager, frame: XRFrame) {
     const ctx = this.ctx;
-    const mesh = projection.getMesh();
     const eyeParams = vr.getEyeParams(frame);
 
     if (!eyeParams || !mesh) return;

--- a/packages/view360/src/plugin/ControlBar/AutoHide.ts
+++ b/packages/view360/src/plugin/ControlBar/AutoHide.ts
@@ -94,7 +94,7 @@ class AutoHide {
     root.addEventListener(BROWSER.EVENTS.MOUSE_LEAVE, this._onMouseLeave);
     this._addFullscreenHandlers();
 
-    const video = viewer.projection?.getTexture();
+    const video = viewer.mesh?.getTexture();
     if (!video || !video.isVideo()) {
       return;
     }

--- a/packages/view360/src/plugin/ControlBar/ControlBar.ts
+++ b/packages/view360/src/plugin/ControlBar/ControlBar.ts
@@ -435,7 +435,7 @@ class ControlBar implements View360Plugin {
     } else {
       if (!this.clickToPlay) return;
 
-      const video = viewer.projection?.getTexture();
+      const video = viewer.mesh?.getTexture();
       if (!video || !video.isVideo()) return;
 
       if (video.isPaused()) {
@@ -475,7 +475,7 @@ class ControlBar implements View360Plugin {
       }
     } else {
       // Automatically choose whether to show background by content type
-      const texture = viewer.projection?.getTexture();
+      const texture = viewer.mesh?.getTexture();
 
       if (texture && texture.isVideo()) {
         // Enable auto hide when content type is video
@@ -499,7 +499,7 @@ class ControlBar implements View360Plugin {
       }
     } else {
       // Automatically choose whether to show background by content type
-      const texture = viewer.projection?.getTexture();
+      const texture = viewer.mesh?.getTexture();
 
       if (texture && texture.isVideo()) {
         // Show bg when content type is video
@@ -513,7 +513,7 @@ class ControlBar implements View360Plugin {
   private _updateKeyboardHandler(viewer: View360) {
     const panoRoot = viewer.rootEl;
     const videoControl = this._videoControl;
-    const texture = viewer.projection?.getTexture();
+    const texture = viewer.mesh?.getTexture();
 
     if (this.keyboardControls && texture && texture.isVideo()) {
       videoControl.enable(panoRoot, texture);

--- a/packages/view360/src/plugin/ControlBar/PlayButton.ts
+++ b/packages/view360/src/plugin/ControlBar/PlayButton.ts
@@ -45,7 +45,7 @@ class PlayButton extends ControlBarItem {
 
   public init(viewer: View360, controlBar: ControlBar) {
     const element = this.element;
-    const video = viewer.projection?.getTexture();
+    const video = viewer.mesh?.getTexture();
     const className = controlBar.className;
     const unavailableClass = className.UNAVAILABLE;
 

--- a/packages/view360/src/plugin/ControlBar/ProgressBar.ts
+++ b/packages/view360/src/plugin/ControlBar/ProgressBar.ts
@@ -59,7 +59,7 @@ class ProgressBar extends ControlBarItem {
   }
 
   public init(viewer: View360, controlBar: ControlBar) {
-    const video = viewer.projection?.getTexture();
+    const video = viewer.mesh?.getTexture();
     const element = this.element;
     const rangeControl = this._rangeControl;
     const unavailableClass = controlBar.className.UNAVAILABLE;

--- a/packages/view360/src/plugin/ControlBar/VideoTime.ts
+++ b/packages/view360/src/plugin/ControlBar/VideoTime.ts
@@ -45,7 +45,7 @@ class VideoTime extends ControlBarItem {
   }
 
   public init(viewer: View360, controlBar: ControlBar) {
-    const video = viewer.projection?.getTexture();
+    const video = viewer.mesh?.getTexture();
     const element = this.element;
     const className = controlBar.className;
 

--- a/packages/view360/src/plugin/ControlBar/VolumeControl.ts
+++ b/packages/view360/src/plugin/ControlBar/VolumeControl.ts
@@ -50,7 +50,7 @@ class VolumeControl extends ControlBarItem {
   }
 
   public init(viewer: View360, controlBar: ControlBar) {
-    const video = viewer.projection?.getTexture();
+    const video = viewer.mesh?.getTexture();
     const root = this._rootEl;
     const button = this._buttonEl;
     const rangeControl = this._rangeControl;

--- a/packages/view360/src/projection/CubemapProjection.ts
+++ b/packages/view360/src/projection/CubemapProjection.ts
@@ -43,9 +43,7 @@ export interface CubemapProjectionOptions extends ProjectionOptions {
  * @since 4.0.0
  * @category Projection
  */
-class CubemapProjection extends Projection<{
-  uTexture: UniformTextureCube | UniformCanvasCube;
-}> {
+class CubemapProjection extends Projection {
   private _cubemapOrder: NonNullable<CubemapProjectionOptions["cubemapOrder"]>;
   private _cubemapFlipX: NonNullable<CubemapProjectionOptions["cubemapFlipX"]>;
 
@@ -66,7 +64,7 @@ class CubemapProjection extends Projection<{
     this._cubemapFlipX = cubemapFlipX;
   }
 
-  public applyTexture(ctx: WebGLContext, texture: Texture2D) {
+  public createMesh(ctx: WebGLContext, texture: Texture2D) {
     const cubemapOrder = this._cubemapOrder;
     const cubemapFlipX = this._cubemapFlipX;
     const uniforms = {
@@ -87,7 +85,7 @@ class CubemapProjection extends Projection<{
     }
     mesh.updateMatrix();
 
-    this._mesh = mesh;
+    return mesh;
   }
 }
 

--- a/packages/view360/src/projection/CubestripProjection.ts
+++ b/packages/view360/src/projection/CubestripProjection.ts
@@ -39,9 +39,7 @@ export interface CubestripProjectionOptions extends ProjectionOptions {
  * @since 4.0.0
  * @category Projection
  */
-class CubestripProjection extends Projection<{
-  uTexture: UniformTexture2D;
-}> {
+class CubestripProjection extends Projection {
   private _cubemapOrder: NonNullable<CubestripProjectionOptions["cubemapOrder"]>;
   private _cubemapFlipX: NonNullable<CubestripProjectionOptions["cubemapFlipX"]>;
 
@@ -62,7 +60,7 @@ class CubestripProjection extends Projection<{
     this._cubemapFlipX = cubemapFlipX;
   }
 
-  public applyTexture(ctx: WebGLContext, texture: Texture2D) {
+  public createMesh(ctx: WebGLContext, texture: Texture2D) {
     const cubemapOrder = this._cubemapOrder;
     const cubemapFlipX = this._cubemapFlipX;
     const uniforms = {
@@ -80,7 +78,7 @@ class CubestripProjection extends Projection<{
     }
     mesh.updateMatrix();
 
-    this._mesh = mesh;
+    return mesh;
   }
 }
 

--- a/packages/view360/src/projection/EquiangularProjection.ts
+++ b/packages/view360/src/projection/EquiangularProjection.ts
@@ -29,10 +29,8 @@ export interface EquiangularProjectionOptions extends ProjectionOptions {}
  * @since 4.0.0
  * @category Projection
  */
-class EquiangularProjection extends Projection<{
-  uTexture: UniformTexture2D;
-}> {
-  public applyTexture(ctx: WebGLContext, texture: Texture2D) {
+class EquiangularProjection extends Projection {
+  public createMesh(ctx: WebGLContext, texture: Texture2D) {
     const uniforms = {
       uTexture: new UniformTexture2D(ctx, texture)
     };
@@ -47,7 +45,7 @@ class EquiangularProjection extends Projection<{
     const vao = ctx.createVAO(geometry, program);
     const mesh = new TriangleMesh(vao, program);
 
-    this._mesh = mesh;
+    return mesh;
   }
 }
 

--- a/packages/view360/src/projection/EquirectProjection.ts
+++ b/packages/view360/src/projection/EquirectProjection.ts
@@ -28,9 +28,7 @@ export interface EquirectProjectionOptions extends ProjectionOptions {
  * @since 4.0.0
  * @category Projection
  */
-class EquirectProjection extends Projection<{
-  uTexture: UniformTexture2D
-}> {
+class EquirectProjection extends Projection {
   /**
    * Create new instance
    * @ko 새로운 인스턴스를 생성합니다.
@@ -40,7 +38,7 @@ class EquirectProjection extends Projection<{
     super(options);
   }
 
-  public applyTexture(ctx: WebGLContext, texture: Texture2D) {
+  public createMesh(ctx: WebGLContext, texture: Texture2D) {
     const uniforms = {
       uTexture: new UniformTexture2D(ctx, texture)
     };
@@ -51,7 +49,7 @@ class EquirectProjection extends Projection<{
     const vao = ctx.createVAO(geometry, program);
     const mesh = new TriangleMesh(vao, program);
 
-    this._mesh = mesh;
+    return mesh;
   }
 }
 

--- a/packages/view360/src/projection/Projection.ts
+++ b/packages/view360/src/projection/Projection.ts
@@ -8,13 +8,6 @@ import TriangleMesh from "../core/TriangleMesh";
 import Texture from "../texture/Texture";
 import WebGLContext from "../core/WebGLContext";
 import { VideoConfig } from "../type/external";
-import UniformCanvasCube from "../uniform/UniformCanvasCube";
-import UniformTexture2D from "../uniform/UniformTexture2D";
-import UniformTextureCube from "../uniform/UniformTextureCube";
-
-type CommonProjectionUniforms = {
-  uTexture: UniformTexture2D | UniformTextureCube | UniformCanvasCube;
-}
 
 /**
  * Common option for {@link Projection}s
@@ -39,7 +32,7 @@ export interface ProjectionOptions {
  * @category Projection
  * @since 4.0.0
  */
-abstract class Projection<T extends CommonProjectionUniforms = CommonProjectionUniforms> {
+abstract class Projection {
   /**
    * Source URL to panorama image/video.
    * @ko 파노라마 이미지/비디오의 URL
@@ -62,8 +55,6 @@ abstract class Projection<T extends CommonProjectionUniforms = CommonProjectionU
    */
   public readonly video: ProjectionOptions["video"];
 
-  protected _mesh: TriangleMesh<T> | null;
-
   /**
    * Create new instance
    * @ko 새로운 인스턴스를 생성합니다.
@@ -75,29 +66,17 @@ abstract class Projection<T extends CommonProjectionUniforms = CommonProjectionU
   }: ProjectionOptions) {
     this.src = src;
     this.video = video;
-    this._mesh = null;
   }
 
   /**
-   * Apply texture to current projection.
-   * @ko 주어진 텍스쳐를 현재 프로젝션에 적용합니다.
+   * Generate triangle mesh from current projection.
+   * @ko 현재 프로젝션으로부터 TriangleMesh의 인스턴스를 생성합니다.
    * @param ctx - Instance of the WebGLContext helper {@ko WebGL context 헬퍼의 인스턴스}
    * @param texture - New texture to apply {@ko 새로 적용할 텍스쳐}
    * @internal
    * @since 4.0.0
    */
-  public abstract applyTexture(ctx: WebGLContext, texture: Texture): void;
-
-  /**
-   * Release all resources projection has.
-   * This is automatically called on projection change & View360's destroy call
-   * @ko 현재 갖고 있는 모든 리소스를 반환합니다.
-   * 이 메소드는 프로젝션 변경 및 View360의 destroy 호출 시 자동으로 호출됩니다.
-   * @param ctx
-   */
-  public releaseAllResources(ctx: WebGLContext) {
-    this._mesh?.destroy(ctx);
-  }
+  public abstract createMesh(ctx: WebGLContext, texture: Texture): TriangleMesh;
 
   /**
    * Update camera to match projection's settings.
@@ -118,35 +97,6 @@ abstract class Projection<T extends CommonProjectionUniforms = CommonProjectionU
    */
   public updateControl(control: PanoControl) {
     control.ignoreZoomScale = false;
-  }
-
-  /**
-   * Update projection.
-   * @ko 현재 프로젝션 정보를 갱신합니다.
-   * @param camera - Instance of the camera to reference {@ko 참조할 카메라의 인스턴스}
-   * @since 4.0.0
-   */
-  public update(camera: Camera) {} // eslint-disable-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars
-
-  /**
-   * Return active texture.
-   * @ko 현재 활성화된 텍스쳐를 반환합니다.
-   * @internal
-   * @since 4.0.0
-   */
-  public getTexture() {
-    if (!this._mesh) return null;
-
-    return this._mesh.program.uniforms.uTexture.texture;
-  }
-
-  /**
-   * A 3D triangle mesh for projection. It's `null` until loading the `src`.
-   * @ko Projection을 표시하기 위한 Mesh, src를 로드하기 전까지는 `null`입니다.
-   * @since 4.0.0
-   */
-  public getMesh(): TriangleMesh<T> | null {
-    return this._mesh;
   }
 }
 

--- a/packages/view360/src/projection/StereoEquiProjection.ts
+++ b/packages/view360/src/projection/StereoEquiProjection.ts
@@ -37,11 +37,7 @@ export interface StereoEquiProjectionOptions extends ProjectionOptions {
  * @since 4.0.0
  * @category Projection
  */
-class StereoEquiProjection extends Projection<{
-  uTexture: UniformTexture2D;
-  uEye: UniformFloat;
-  uTexScaleOffset: UniformVector4Array;
-}> {
+class StereoEquiProjection extends Projection {
   /**
    * Available stereoscopic modes
    * @ko 사용가능한 스테레오스코픽 모드들
@@ -73,7 +69,7 @@ class StereoEquiProjection extends Projection<{
     this._mode = options.mode;
   }
 
-  public applyTexture(ctx: WebGLContext, texture: Texture2D) {
+  public createMesh(ctx: WebGLContext, texture: Texture2D) {
     let leftEye: number[];
     let rightEye: number[];
 
@@ -101,7 +97,7 @@ class StereoEquiProjection extends Projection<{
     const vao = ctx.createVAO(geometry, program);
     const mesh = new TriangleMesh(vao, program);
 
-    this._mesh = mesh;
+    return mesh;
   }
 }
 

--- a/packages/view360/src/utils.ts
+++ b/packages/view360/src/utils.ts
@@ -140,7 +140,7 @@ export const isFullscreen = () => {
 };
 
 export const sensorCanBeEnabledIOS = () => {
-  return !!DeviceMotionEvent && "requestPermission" in DeviceMotionEvent && window.isSecureContext;
+  return window.isSecureContext && !!DeviceMotionEvent && "requestPermission" in DeviceMotionEvent;
 };
 
 export const hfovToZoom = (baseFov: number, fov: number) => {

--- a/packages/vue-view360/demo/Demo.vue
+++ b/packages/vue-view360/demo/Demo.vue
@@ -1,19 +1,36 @@
 <template>
-  <div>
-    <View360 :projection="projection" />
+  <div class="wrapper">
+    <View360
+      ref="view360"
+      class="is-1by1"
+      :projection="projection"
+      :plugins="plugins"
+    />
   </div>
 </template>
 <script>
-import { View360, EquirectProjection } from "../src/index";
+import { View360, EquirectProjection, ControlBar } from "../src";
+import "@egjs/view360/css/view360.min.css";
 
 export default {
-  created() {
-    this.projection = new EquirectProjection({
-      src: "https://iili.io/HGJXXr7.jpg"
-    });
+  data() {
+    return {
+      projection: new EquirectProjection({
+        src: "https://iili.io/HGJXXr7.jpg",
+      }),
+      plugins: [new ControlBar()],
+    };
   },
   components: {
-    View360
-  }
-}
+    View360,
+  },
+};
 </script>
+<style scoped>
+.wrapper {
+  width: 400px;
+}
+.inv {
+  display: none;
+}
+</style>

--- a/packages/vue-view360/src/View360.ts
+++ b/packages/vue-view360/src/View360.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2023-present NAVER Corp.
  * egjs projects are licensed under the MIT license
  */
-import Vue, { CreateElement, isProxy } from "vue";
+import Vue, { CreateElement } from "vue";
 import VanillaView360, {
   DEFAULT_CLASS,
   EVENTS,
@@ -56,11 +56,6 @@ export default Vue.extend<{
   },
   mounted() {
     const props = getValidProps(this.$props);
-
-    if (props.projection && isProxy(props.projection)) {
-      // props.projection = Object.assign({}, props.projection);
-      console.log(props.projection);
-    }
 
     this._view360 = new VanillaView360(
       this.$refs.container as HTMLElement,

--- a/packages/vue-view360/src/View360.ts
+++ b/packages/vue-view360/src/View360.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2023-present NAVER Corp.
  * egjs projects are licensed under the MIT license
  */
-import Vue, { CreateElement } from "vue";
+import Vue, { CreateElement, isProxy } from "vue";
 import VanillaView360, {
   DEFAULT_CLASS,
   EVENTS,
@@ -56,6 +56,11 @@ export default Vue.extend<{
   },
   mounted() {
     const props = getValidProps(this.$props);
+
+    if (props.projection && isProxy(props.projection)) {
+      // props.projection = Object.assign({}, props.projection);
+      console.log(props.projection);
+    }
 
     this._view360 = new VanillaView360(
       this.$refs.container as HTMLElement,


### PR DESCRIPTION
## Details
This fixes low WebGL performance due to Vue's proxy wrapping when using `projection` in `data()`.
basic demo to reproduce this issue:

```js
<template>
  <div class="wrapper">
    <View360
      ref="view360"
      class="is-1by1"
      :projection="projection"
    />
  </div>
</template>
<script>
import { View360, EquirectProjection } from "@egjs/vue-view360";
import "@egjs/view360/css/view360.min.css";

export default {
  data() {
    return {
      projection: new EquirectProjection({
        src: "https://iili.io/HGJXXr7.jpg",
      })
    };
  },
  components: {
    View360,
  },
};
</script>
```